### PR TITLE
Allow exact regex match and multiple tickets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+dist/
+*.egg-info/
+.tox/

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Features
 This hook saves developers time by prepending ticket numbers to commit-msgs.
 For this to work the following two conditions must be met:
    - The ticket format regex specified must match, if the regex is passed in.
-   - The branch name format must be <ticket number>_<rest of the branch name>
+   - Unless you use ``regex_match`` mode, the branch name format must be <ticket number>_<rest of the branch name>
 
 For e.g. if you name your branch ``JIRA-1234_awesome_feature`` and commit ``Fix some bug``, the commit will be updated to ``JIRA-1234 Fix some bug``.
 
@@ -39,6 +39,8 @@ By default it's ``[A-Z]+-\d+``.
 Pass ``--format=`` or update ``args: [--format=<custom template string>]`` in your .yaml file if you have custom message replacement.
 By default it's ``'{ticket} {commit_msg}``, where ``ticket`` is replaced with the found ticket number and ``commit_msg`` is replaced with the original commit message.
 
+Pass ``--mode=`` or update ``args: [--mode=regex_match]`` in your .yaml file to extract ticket by the regex rather than relying on branch name convention.
+With this mode you can also make use of ``{tickets}`` placeholder in ``format`` argument value to put multiple comma-separated tickets in the commit message in case your branch contains more than one ticket.
 
 It is best used along with pre-commit_. You can use it along with pre-commit by adding the following hook in your ``.pre-commit-config.yaml`` file.
 

--- a/giticket/giticket.py
+++ b/giticket/giticket.py
@@ -33,15 +33,12 @@ def update_commit_message(filename, regex, mode, format_string):
 
             new_commit_msg = format_string.format(
                 ticket=tickets[0], tickets=', '.join(tickets),
-                commit_msg=commit_msg.strip()
+                commit_msg=commit_msg
             )
 
+            contents[0] = six.text_type(new_commit_msg)
             fd.seek(0)
-            fd.write(
-                six.text_type(
-                    new_commit_msg,
-                ),
-            )
+            fd.writelines(contents)
             fd.truncate()
 
 

--- a/tests/test_giticket.py
+++ b/tests/test_giticket.py
@@ -9,24 +9,100 @@ from giticket.giticket import get_branch_name
 from giticket.giticket import main
 from giticket.giticket import update_commit_message
 
-
 TESTING_MODULE = 'giticket.giticket'
 
 
-@pytest.mark.parametrize(
-    ('msg'),
-    (
-        'Test',
-        'JIRA-1234_Test',
-    ),
-)
+@pytest.mark.parametrize('msg', (
+    'Test ABC-1 message',
+    'ABC-2 Test message',
+    'Test message ABC-3',
+))
 @mock.patch(TESTING_MODULE + '.get_branch_name')
-def test_update_commit_message(mock_branch_name, msg, tmpdir):
+def test_update_commit_message_no_modification(mock_branch_name, msg, tmpdir):
     mock_branch_name.return_value = 'JIRA-1234_new_feature'
     path = tmpdir.join('file.txt')
     path.write(msg)
-    update_commit_message(six.text_type(path), '[A-Z]+-\d+', '{ticket} {commit_msg}')
-    assert 'JIRA-1234' in path.read()
+    update_commit_message(six.text_type(path), '[A-Z]+-\d+',
+                          'underscore_split', '{ticket} {commit_msg}')
+    # Message should remain intact as it contains some ticket
+    assert path.read() == msg
+
+
+@pytest.mark.parametrize('test_data', (
+    ('JIRA-1234', 'JIRA-1234'),
+    ('JIRA-1234_bar', 'JIRA-1234'),
+    ('foo-JIRA-1234_bar', 'foo-JIRA-1234'),
+    ('foo/JIRA-1234-bar', 'foo/JIRA-1234-bar'),
+    ('foo_JIRA-1234_bar', 'foo'),
+))
+@mock.patch(TESTING_MODULE + '.get_branch_name')
+def test_update_commit_message_underscore_split_mode(mock_branch_name,
+                                                     test_data, tmpdir):
+    mock_branch_name.return_value = test_data[0]
+    path = tmpdir.join('file.txt')
+    path.write('Test commit message')
+    update_commit_message(six.text_type(path), '[A-Z]+-\d+',
+                          'underscore_split', '{ticket}: {commit_msg}')
+    assert path.read() == '{expected_ticket}: Test commit message'.format(
+        expected_ticket=test_data[1]
+    )
+
+
+@pytest.mark.parametrize('branch_name', (
+    'JIRA-1234',
+    'JIRA-1234_bar',
+    'foo_JIRA-1234_bar',
+    'foo-JIRA-1234-bar',
+    'foo/JIRA-1234-bar',
+    'fooJIRA-1234bar',
+    'foo/bar/JIRA-1234',
+))
+@mock.patch(TESTING_MODULE + '.get_branch_name')
+def test_update_commit_message_regex_match_mode(mock_branch_name,
+                                                branch_name, tmpdir):
+    mock_branch_name.return_value = branch_name
+    path = tmpdir.join('file.txt')
+    path.write('Test commit message')
+    update_commit_message(six.text_type(path), '[A-Z]+-\d+',
+                          'regex_match', '{ticket}: {commit_msg}')
+    assert path.read() == 'JIRA-1234: Test commit message'
+
+
+@pytest.mark.parametrize('test_data', (
+    ('JIRA-1234', 'JIRA-1234'),
+    ('JIRA-1234-JIRA-239', 'JIRA-1234'),
+    ('JIRA-239-JIRA-1234', 'JIRA-239'),
+))
+@mock.patch(TESTING_MODULE + '.get_branch_name')
+def test_update_commit_message_multiple_ticket_first_selected(mock_branch_name,
+                                                              test_data,
+                                                              tmpdir):
+    mock_branch_name.return_value = test_data[0]
+    path = tmpdir.join('file.txt')
+    path.write('Test commit message')
+    update_commit_message(six.text_type(path), '[A-Z]+-\d+',
+                          'regex_match', '{ticket}: {commit_msg}')
+    assert path.read() == '{expected_ticket}: Test commit message'.format(
+        expected_ticket=test_data[1]
+    )
+
+
+@pytest.mark.parametrize('test_data', (
+    ('JIRA-1234', 'JIRA-1234'),
+    ('JIRA-1234-JIRA-239', 'JIRA-1234, JIRA-239'),
+    ('JIRA-239-JIRA-1234', 'JIRA-239, JIRA-1234'),
+))
+@mock.patch(TESTING_MODULE + '.get_branch_name')
+def test_update_commit_message_multiple_ticket_all_selected(mock_branch_name,
+                                                            test_data, tmpdir):
+    mock_branch_name.return_value = test_data[0]
+    path = tmpdir.join('file.txt')
+    path.write('Test commit message')
+    update_commit_message(six.text_type(path), '[A-Z]+-\d+',
+                          'regex_match', '{tickets}: {commit_msg}')
+    assert path.read() == '{expected_tickets}: Test commit message'.format(
+        expected_tickets=test_data[1]
+    )
 
 
 @mock.patch(TESTING_MODULE + '.subprocess')
@@ -49,6 +125,9 @@ def test_main(mock_update_commit_message, mock_argparse):
     mock_args.filenames = ['foo.txt']
     mock_args.regex = None
     mock_args.format = None
+    mock_args.mode = 'underscore_split'
     mock_argparse.ArgumentParser.return_value.parse_args.return_value = mock_args
     main()
-    mock_update_commit_message.assert_called_once_with('foo.txt', '[A-Z]+-\d+', '{ticket} {commit_msg}')
+    mock_update_commit_message.assert_called_once_with('foo.txt', '[A-Z]+-\d+',
+                                                       'underscore_split',
+                                                       '{ticket} {commit_msg}')

--- a/tests/test_giticket.py
+++ b/tests/test_giticket.py
@@ -11,6 +11,8 @@ from giticket.giticket import update_commit_message
 
 TESTING_MODULE = 'giticket.giticket'
 
+COMMIT_MESSAGE = 'Test commit message\n\nFoo bar\nBaz qux'
+
 
 @pytest.mark.parametrize('msg', (
     'Test ABC-1 message',
@@ -40,11 +42,11 @@ def test_update_commit_message_underscore_split_mode(mock_branch_name,
                                                      test_data, tmpdir):
     mock_branch_name.return_value = test_data[0]
     path = tmpdir.join('file.txt')
-    path.write('Test commit message')
+    path.write(COMMIT_MESSAGE)
     update_commit_message(six.text_type(path), '[A-Z]+-\d+',
                           'underscore_split', '{ticket}: {commit_msg}')
-    assert path.read() == '{expected_ticket}: Test commit message'.format(
-        expected_ticket=test_data[1]
+    assert path.read() == '{expected_ticket}: {message}'.format(
+        expected_ticket=test_data[1], message=COMMIT_MESSAGE
     )
 
 
@@ -62,10 +64,10 @@ def test_update_commit_message_regex_match_mode(mock_branch_name,
                                                 branch_name, tmpdir):
     mock_branch_name.return_value = branch_name
     path = tmpdir.join('file.txt')
-    path.write('Test commit message')
+    path.write(COMMIT_MESSAGE)
     update_commit_message(six.text_type(path), '[A-Z]+-\d+',
                           'regex_match', '{ticket}: {commit_msg}')
-    assert path.read() == 'JIRA-1234: Test commit message'
+    assert path.read() == 'JIRA-1234: {message}'.format(message=COMMIT_MESSAGE)
 
 
 @pytest.mark.parametrize('test_data', (
@@ -79,11 +81,11 @@ def test_update_commit_message_multiple_ticket_first_selected(mock_branch_name,
                                                               tmpdir):
     mock_branch_name.return_value = test_data[0]
     path = tmpdir.join('file.txt')
-    path.write('Test commit message')
+    path.write(COMMIT_MESSAGE)
     update_commit_message(six.text_type(path), '[A-Z]+-\d+',
                           'regex_match', '{ticket}: {commit_msg}')
-    assert path.read() == '{expected_ticket}: Test commit message'.format(
-        expected_ticket=test_data[1]
+    assert path.read() == '{expected_ticket}: {message}'.format(
+        expected_ticket=test_data[1], message=COMMIT_MESSAGE
     )
 
 
@@ -97,11 +99,11 @@ def test_update_commit_message_multiple_ticket_all_selected(mock_branch_name,
                                                             test_data, tmpdir):
     mock_branch_name.return_value = test_data[0]
     path = tmpdir.join('file.txt')
-    path.write('Test commit message')
+    path.write(COMMIT_MESSAGE)
     update_commit_message(six.text_type(path), '[A-Z]+-\d+',
                           'regex_match', '{tickets}: {commit_msg}')
-    assert path.read() == '{expected_tickets}: Test commit message'.format(
-        expected_tickets=test_data[1]
+    assert path.read() == '{expected_tickets}: {message}'.format(
+        expected_tickets=test_data[1], message=COMMIT_MESSAGE
     )
 
 


### PR DESCRIPTION
Rather than constraining branch name format, new `regex_match` mode
will extract all tickets from the branch name using the provided
regular expression, so something like `foo/ABC-1-bar` or even
`fooABC-1bar` would result in `ABC-1` ticket with the default regex.

Multiple tickets are now supported too. In addition to existing
`{ticket}` placeholder there's now new one `{tickets}` placeholder,
and these two now work as follows:

- In `underscore_match` mode both placeholders will work exactly
  the same way, just as `{ticket}` did before this change. Branch
  name is split by the first underscore symbol, the only ticket
  extracted is the first element.
- In `regex_match` mode `{ticket}` placeholder will be replaced
  with the first ticket found in the branch name, while `{tickets}`
  placeholder will be replaced with a comma-separated list of all
  tickets found in the branch name.