### PR TITLE
Upstream pre commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    -   id: trailing-whitespace
+        stages: [commit]
+    -   id: end-of-file-fixer
+        stages: [commit]
+    -   id: check-yaml
+        stages: [commit]
+    -   id: check-added-large-files
+        stages: [commit]
+-   repo: https://github.com/pycqa/flake8
+    rev: '3.9.1'
+    hooks:
+    -   id: flake8
+        stages: [commit]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,7 +73,8 @@ Ready to contribute? Here's how to set up `giticket` for local development.
 4. Set up pre-commit::
 
     $ pip install pre-commit
-    $ pre-commit install --install-hooks
+    $ pre-commit install
+    $ pre-commit install --hook-type commit-msg
 
 5. Create a branch for local development::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -70,28 +70,33 @@ Ready to contribute? Here's how to set up `giticket` for local development.
     $ cd giticket/
     $ python setup.py develop
 
-4. Create a branch for local development::
+4. Set up pre-commit::
+
+    $ pip install pre-commit
+    $ pre-commit install --install-hooks
+
+5. Create a branch for local development::
 
     $ git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
+6. When you're done making changes, check that your changes pass flake8 and the
    tests, including testing other Python versions with tox::
 
-    $ flake8 giticket tests
+    $ flake8 giticket tests      # flake8 will also run on commit
     $ python setup.py test or py.test
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
 
-6. Commit your changes and push your branch to GitHub::
+7. Commit your changes and push your branch to GitHub::
 
     $ git add .
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Submit a pull request through the GitHub website.
+8. Submit a pull request through the GitHub website.
 
 Pull Request Guidelines
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,8 @@ You need to have precommit setup to use this hook.
    ::
 
         pip install pre-commit
-        pre-commit install --install-hooks
+        pre-commit install
+        pre-commit install --hook-type commit-msg
 
 
 .. _pre-commit: https://pre-commit.com/

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,7 @@ You need to have precommit setup to use this hook.
    ::
 
         pip install pre-commit
-        pre-commit install
-        pre-commit install --hook-type commit-msg
+        pre-commit install --install-hooks
 
 
 .. _pre-commit: https://pre-commit.com/


### PR DESCRIPTION
This PR sets up pre-commit on the repo itself. It enables a few simple tests, and then turns on flake8 on commit.

Docs are also updated to simplify the installation, and to instruct developers on how to set up pre-commit themselves.