### PR TITLE
fix: bail if the commit message use a fixup! prefix

### DIFF
--- a/giticket/giticket.py
+++ b/giticket/giticket.py
@@ -21,8 +21,8 @@ def update_commit_message(filename, regex, mode, format_string):
         # Check if we can grab ticket info from branch name.
         branch = get_branch_name()
 
-        # Bail if commit message already contains tickets
-        if any(re.search(regex, content) for content in contents):
+        # Bail if commit message starts with “fixup!” or commit message already contains tickets
+        if commit_msg.startswith('fixup!') or any(re.search(regex, content) for content in contents):
             return
 
         tickets = re.findall(regex, branch)

--- a/tests/test_giticket.py
+++ b/tests/test_giticket.py
@@ -142,6 +142,21 @@ def test_update_commit_message_no_modification_if_ticket_in_body(mock_branch_nam
     assert path.read() == msg
 
 
+@pytest.mark.parametrize('msg', (
+    """fixup! A descriptive header
+
+A descriptive body.""",
+))
+@mock.patch(TESTING_MODULE + '.get_branch_name')
+def test_update_commit_message_no_modification_if_commit_is_a_fixup(mock_branch_name, msg, tmpdir):
+    mock_branch_name.return_value = "team_name/2397/a_nice_feature"
+    path = tmpdir.join('file.txt')
+    path.write(msg)
+    update_commit_message(six.text_type(path), r'\d{4,}',
+                          'regex_match', '{commit_msg}\n\nIssue: {ticket}')
+    assert path.read() == msg
+
+
 @mock.patch(TESTING_MODULE + '.subprocess')
 def test_get_branch_name(mock_subprocess):
     get_branch_name()


### PR DESCRIPTION
First of all, thanks for your work ! 

When I use the `--fixup` option the issue number keep repeating itself each time. As a reminder "fixup" commit reference the targeted commit message (which may already contain the issue number), regardless of if the issue number is present or not, `--autosquash` feature combine commits with the exact same message.

This PR bails on every message starting with `fixup!` tag ([documentation](https://git-scm.com/docs/git-commit/2.32.0#Documentation/git-commit.txt---fixupamendrewordltcommitgt))

