### PR TITLE
feat: added --conventionalcommit switch

### DIFF
--- a/giticket/giticket.py
+++ b/giticket/giticket.py
@@ -12,9 +12,9 @@ import six
 
 underscore_split_mode = 'underscore_split'
 regex_match_mode = 'regex_match'
-conventional_commit_regex = r'^(?P<type>build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\((?P<scope>.+)\))?: (?P<subject>.+)'
+conventionalcommit_regex = r'^(?P<type>build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\((?P<scope>.+)\))?: (?P<subject>.+)'
 
-def update_commit_message(filename, regex, mode, format_string, conventional_commits=False):
+def update_commit_message(filename, regex, mode, format_string, conventionalcommits=False):
     with io.open(filename, 'r+') as fd:
         contents = fd.readlines()
         commit_msg = contents[0].rstrip('\r\n')
@@ -31,7 +31,7 @@ def update_commit_message(filename, regex, mode, format_string, conventional_com
                 tickets = [branch.split(six.text_type('_'))[0]]
             tickets = [t.strip() for t in tickets]
 
-            if conventional_commits and (match := re.match(conventional_commit_regex, commit_msg)):
+            if conventionalcommits and (match := re.match(conventionalcommit_regex, commit_msg)):
                 # If the commit message matches the Conventional Commits spec, we can use the captured groups.
                 type = match.group('type')
                 scope = match.group('scope')

--- a/giticket/giticket.py
+++ b/giticket/giticket.py
@@ -14,7 +14,7 @@ underscore_split_mode = 'underscore_split'
 regex_match_mode = 'regex_match'
 conventional_commit_regex = r'^(?P<type>build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\((?P<scope>.+)\))?: (?P<subject>.+)'
 
-def update_commit_message(filename, regex, mode, format_string, conventional_commits):
+def update_commit_message(filename, regex, mode, format_string, conventional_commits=False):
     with io.open(filename, 'r+') as fd:
         contents = fd.readlines()
         commit_msg = contents[0].rstrip('\r\n')

--- a/giticket/giticket.py
+++ b/giticket/giticket.py
@@ -12,9 +12,9 @@ import six
 
 underscore_split_mode = 'underscore_split'
 regex_match_mode = 'regex_match'
+conventional_commit_regex = r'^(?P<type>build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\((?P<scope>.+)\))?: (?P<subject>.+)'
 
-
-def update_commit_message(filename, regex, mode, format_string):
+def update_commit_message(filename, regex, mode, format_string, conventional_commits):
     with io.open(filename, 'r+') as fd:
         contents = fd.readlines()
         commit_msg = contents[0].rstrip('\r\n')
@@ -31,10 +31,24 @@ def update_commit_message(filename, regex, mode, format_string):
                 tickets = [branch.split(six.text_type('_'))[0]]
             tickets = [t.strip() for t in tickets]
 
-            new_commit_msg = format_string.format(
-                ticket=tickets[0], tickets=', '.join(tickets),
-                commit_msg=commit_msg
-            )
+            if conventional_commits and (match := re.match(conventional_commit_regex, commit_msg)):
+                # If the commit message matches the Conventional Commits spec, we can use the captured groups.
+                type = match.group('type')
+                scope = match.group('scope')
+                if scope:
+                    scope = scope + ',' + ', '.join(tickets)
+                else:
+                    scope = ', '.join(tickets)
+                subject = match.group('subject')
+                format_string = '{type}({scope}): {subject}'
+                new_commit_msg = format_string.format(
+                    type=type, scope=scope, subject=subject
+                )
+            else:
+                new_commit_msg = format_string.format(
+                    ticket=tickets[0], tickets=', '.join(tickets),
+                    commit_msg=commit_msg
+                )
 
             contents[0] = six.text_type(new_commit_msg + "\n")
             fd.seek(0)
@@ -63,15 +77,19 @@ def main(argv=None):
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='+')
+    parser.add_argument('--conventionalcommits', action='store_true')
     parser.add_argument('--regex')
-    parser.add_argument('--format')
+    parser.add_argument('--format', nargs='?')
     parser.add_argument('--mode', nargs='?', const=underscore_split_mode,
                         default=underscore_split_mode,
                         choices=[underscore_split_mode, regex_match_mode])
     args = parser.parse_args(argv)
+    if not args.conventionalcommits and not args.format:
+        parser.error('You must provide --format if not using --conventionalcommits')
+        return 1
     regex = args.regex or r'[A-Z]+-\d+'  # noqa
     format_string = args.format or '{ticket} {commit_msg}' # noqa
-    update_commit_message(args.filenames[0], regex, args.mode, format_string)
+    update_commit_message(args.filenames[0], regex, args.mode, format_string, args.conventionalcommits)
 
 
 if __name__ == '__main__':

--- a/tests/test_giticket.py
+++ b/tests/test_giticket.py
@@ -127,12 +127,12 @@ def test_ci_message_with_nl_regex_match_mode(mock_branch_name, msg, tmpdir):
 # create a unit test to verify that if the --conventionalcommits flag is set,
 # the commit message is updated according to the conventional commit format
 @mock.patch(TESTING_MODULE + '.get_branch_name')
-def test_update_commit_message_conventional_commits(mock_branch_name, tmpdir):
+def test_update_commit_message_conventionalcommits(mock_branch_name, tmpdir):
     mock_branch_name.return_value = "JIRA-5678_new_feature"
     path = tmpdir.join('file.txt')
     path.write("feat: add new feature")
     update_commit_message(six.text_type(path), r'[A-Z]+-\d+',
-                          'regex_match', '{commit_msg}', conventional_commits=True)
+                          'regex_match', '{commit_msg}', conventionalcommits=True)
     assert path.read() == "feat(JIRA-5678): add new feature\n"
 
 @pytest.mark.parametrize('msg', (

--- a/tests/test_giticket.py
+++ b/tests/test_giticket.py
@@ -124,6 +124,16 @@ def test_ci_message_with_nl_regex_match_mode(mock_branch_name, msg, tmpdir):
                           'regex_match', '{commit_msg} - {ticket}')
     assert path.read().split('\n')[0] == "{first_line} - {ticket}".format(first_line=first_line, ticket="JIRA-239")
 
+# create a unit test to verify that if the --conventionalcommits flag is set,
+# the commit message is updated according to the conventional commit format
+@mock.patch(TESTING_MODULE + '.get_branch_name')
+def test_update_commit_message_conventional_commits(mock_branch_name, tmpdir):
+    mock_branch_name.return_value = "JIRA-5678_new_feature"
+    path = tmpdir.join('file.txt')
+    path.write("feat: add new feature")
+    update_commit_message(six.text_type(path), r'[A-Z]+-\d+',
+                          'regex_match', '{commit_msg}', conventional_commits=True)
+    assert path.read() == "feat(JIRA-5678): add new feature\n"
 
 @pytest.mark.parametrize('msg', (
     """A descriptive header
@@ -178,8 +188,10 @@ def test_main(mock_update_commit_message, mock_argparse):
     mock_args.regex = None
     mock_args.format = None
     mock_args.mode = 'underscore_split'
+    mock_args.conventionalcommits = True
     mock_argparse.ArgumentParser.return_value.parse_args.return_value = mock_args
     main()
     mock_update_commit_message.assert_called_once_with('foo.txt', r'[A-Z]+-\d+',
                                                        'underscore_split',
-                                                       '{ticket} {commit_msg}')
+                                                       '{ticket} {commit_msg}',
+                                                       True)


### PR DESCRIPTION
Using `--conventionalcommit` is a replacement for `--format` and automatically appends the ticket to the scope.

This covers my needs, but I'm glad to add improvements to make it more general.